### PR TITLE
Delete v1 Android embedding references from KeepScreenOnPlugin.kt

### DIFF
--- a/keep_screen_on/CHANGELOG.md
+++ b/keep_screen_on/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 3.1.0
+
+- Delete references to Android v1 embedding, which the Flutter team intends to remove from the engine.
+
 ## 3.0.0
 
 - **Breaking change**. Changed arguments for turnOn methods from positional parameters to named parameters.(Changed ```turnOn(false)``` to ```turnOn(on: false)```.)

--- a/keep_screen_on/android/src/main/kotlin/dev/craftsoft/keepscreenon/KeepScreenOnPlugin.kt
+++ b/keep_screen_on/android/src/main/kotlin/dev/craftsoft/keepscreenon/KeepScreenOnPlugin.kt
@@ -140,24 +140,8 @@ public class KeepScreenOnPlugin: FlutterPlugin, MethodCallHandler, ActivityAware
     result.success(true);
   }
 
-  // This static function is optional and equivalent to onAttachedToEngine. It supports the old
-  // pre-Flutter-1.12 Android projects. You are encouraged to continue supporting
-  // plugin registration via this function while apps migrate to use the new Android APIs
-  // post-flutter-1.12 via https://flutter.dev/go/android-project-migration.
-  //
-  // It is encouraged to share logic between onAttachedToEngine and registerWith to keep
-  // them functionally equivalent. Only one of onAttachedToEngine or registerWith will be called
-  // depending on the user's project. onAttachedToEngine or registerWith must both be defined
-  // in the same class.
   companion object {
     const val TAG = "KeepScreenOnPlugin";
     const val CHANNEL_NAME = "dev.craftsoft/keep_screen_on";
-
-    @Suppress("DEPRECATION")
-    @JvmStatic
-    fun registerWith(registrar: io.flutter.plugin.common.PluginRegistry.Registrar) {
-      val channel = MethodChannel(registrar.messenger(), CHANNEL_NAME)
-      channel.setMethodCallHandler(KeepScreenOnPlugin())
-    }
   }
 }


### PR DESCRIPTION
These deprecated APIs are finally being removed:
https://docs.flutter.dev/release/breaking-changes/android-v1-embedding-create-deprecation

Other community plugins are being migrated, example: https://github.com/fluttercommunity/flutter_webview_plugin/issues/974
https://github.com/pichillilorenzo/flutter_inappwebview/issues/2175
https://github.com/fluttercommunity/plus_plugins/pull/2864